### PR TITLE
react-application-announcements - Handle empty start and end values

### DIFF
--- a/samples/react-application-announcements/README.md
+++ b/samples/react-application-announcements/README.md
@@ -66,7 +66,7 @@ The Announcements list must have the following columns. Also note that a PnP Pro
 
 Column|Type|Values
 ------|----|------
-Locale|Choice|`en-US`, `fr-FR`, ...
+Locale|Choice|`en-US`, `fr-FR`, `es-ES`, ...
 Announcement|Note|
 Link|URL|
 Urgent|Boolean|

--- a/samples/react-application-announcements/src/extensions/announcements/components/Announcements.tsx
+++ b/samples/react-application-announcements/src/extensions/announcements/components/Announcements.tsx
@@ -40,7 +40,7 @@ export default function RenderAnnouncements(props: IAnnouncementsProps) {
         Web(props.siteUrl)
             .lists.getByTitle(props.listName)
             .items
-            .filter(`(Locale eq '${props.culture}' or Locale eq null) and (StartDateTime le datetime'${now}' and EndDateTime ge datetime'${now}')`)
+            .filter(`(Locale eq '${props.culture}' or Locale eq null) and (StartDateTime le datetime'${now}' or StartDateTime eq null) and (EndDateTime ge datetime'${now}' or EndDateTime eq null)`)
             .select("ID", "Title", "Announcement", "Urgent", "Link", "Locale", "StartDateTime", "EndDateTime")
             .get<IAnnouncementItem[]>()
             .then(setAnnouncements);


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                             |
| New sample?     | no                           |
| Related issues? |  |

## What's in this Pull Request?
Handle empty start and end dates for announcements.