### PR TITLE
Updated SFPX to SPFX in samples.json files

### DIFF
--- a/samples/jquery-application-toastr/assets/sample.json
+++ b/samples/jquery-application-toastr/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/jquery-field-itemorder/assets/sample.json
+++ b/samples/jquery-field-itemorder/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-alert-message/assets/sample.json
+++ b/samples/js-application-alert-message/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-analytics/assets/sample.json
+++ b/samples/js-application-analytics/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-appinsights-advanced/assets/sample.json
+++ b/samples/js-application-appinsights-advanced/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-appinsights/assets/sample.json
+++ b/samples/js-application-appinsights/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-dynamically-importing-styles/assets/sample.json
+++ b/samples/js-application-dynamically-importing-styles/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-graph-client/assets/sample.json
+++ b/samples/js-application-graph-client/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-header-toggler/assets/sample.json
+++ b/samples/js-application-header-toggler/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-intranet-searchbox/assets/sample.json
+++ b/samples/js-application-intranet-searchbox/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-listdrivenplaceholders/assets/sample.json
+++ b/samples/js-application-listdrivenplaceholders/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-redirect/assets/sample.json
+++ b/samples/js-application-redirect/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-application-run-once/assets/sample.json
+++ b/samples/js-application-run-once/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [],
     "authors": [

--- a/samples/js-command-clone/assets/sample.json
+++ b/samples/js-command-clone/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-command-convert-to-pdf/assets/sample.json
+++ b/samples/js-command-convert-to-pdf/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-command-copy-classic-link/assets/sample.json
+++ b/samples/js-command-copy-classic-link/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-command-hide-commands/assets/sample.json
+++ b/samples/js-command-hide-commands/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-command-item-permissions/assets/sample.json
+++ b/samples/js-command-item-permissions/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-command-lock-item/assets/sample.json
+++ b/samples/js-command-lock-item/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-command-selecteditems-export/assets/sample.json
+++ b/samples/js-command-selecteditems-export/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-field-conditionalformatting/assets/sample.json
+++ b/samples/js-field-conditionalformatting/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-field-taskpriority/assets/sample.json
+++ b/samples/js-field-taskpriority/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-field-weather/assets/sample.json
+++ b/samples/js-field-weather/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/js-guest-message/assets/sample.json
+++ b/samples/js-guest-message/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-aadtokenprovider-bot/assets/sample.json
+++ b/samples/react-aadtokenprovider-bot/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-app-announcements/assets/sample.json
+++ b/samples/react-app-announcements/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-alerts/assets/sample.json
+++ b/samples/react-application-alerts/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-announcements/assets/sample.json
+++ b/samples/react-application-announcements/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-botframework-chat/assets/sample.json
+++ b/samples/react-application-botframework-chat/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-breadcrumb/assets/sample.json
+++ b/samples/react-application-breadcrumb/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-collab-footer/assets/sample.json
+++ b/samples/react-application-collab-footer/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-duetasks/assets/sample.json
+++ b/samples/react-application-duetasks/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-festivals/assets/sample.json
+++ b/samples/react-application-festivals/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-grouplinks/assets/sample.json
+++ b/samples/react-application-grouplinks/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-injectcss/assets/sample.json
+++ b/samples/react-application-injectcss/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-logo-festoon/assets/sample.json
+++ b/samples/react-application-logo-festoon/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-machine-translations/assets/sample.json
+++ b/samples/react-application-machine-translations/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-myfavourites/assets/sample.json
+++ b/samples/react-application-myfavourites/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-myfollowedsites/assets/sample.json
+++ b/samples/react-application-myfollowedsites/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-news-ticker/assets/sample.json
+++ b/samples/react-application-news-ticker/assets/sample.json
@@ -26,7 +26,7 @@
     ],
     "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-office-groups-nav/assets/sample.json
+++ b/samples/react-application-office-groups-nav/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-page-comments-sentiment/assets/sample.json
+++ b/samples/react-application-page-comments-sentiment/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-page-related-bing-news/assets/sample.json
+++ b/samples/react-application-page-related-bing-news/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-portal-footer/assets/sample.json
+++ b/samples/react-application-portal-footer/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-pva-bot/assets/sample.json
+++ b/samples/react-application-pva-bot/assets/sample.json
@@ -27,7 +27,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-qna-chat/assets/sample.json
+++ b/samples/react-application-qna-chat/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-regions-footer/assets/sample.json
+++ b/samples/react-application-regions-footer/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-search-dynamicdata/assets/sample.json
+++ b/samples/react-application-search-dynamicdata/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-sitepagecoremetadata/assets/sample.json
+++ b/samples/react-application-sitepagecoremetadata/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-sites-hubsite-switcher/assets/sample.json
+++ b/samples/react-application-sites-hubsite-switcher/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-team-archived-notification/assets/sample.json
+++ b/samples/react-application-team-archived-notification/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-tenant-global-navbar/assets/sample.json
+++ b/samples/react-application-tenant-global-navbar/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-application-webhooks-notification/assets/sample.json
+++ b/samples/react-application-webhooks-notification/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-bot-framework-secure/assets/sample.json
+++ b/samples/react-bot-framework-secure/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-bot-framework-sso/assets/sample.json
+++ b/samples/react-bot-framework-sso/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-addfolders/assets/sample.json
+++ b/samples/react-command-addfolders/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-convert-to-pdf/assets/sample.json
+++ b/samples/react-command-convert-to-pdf/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-copy-pnp-search-webpart-settings/assets/sample.json
+++ b/samples/react-command-copy-pnp-search-webpart-settings/assets/sample.json
@@ -26,7 +26,7 @@
         ],
         "tags": [],
         "categories": [
-            "SFPX-APPLICATION-EXTENSION"
+            "SPFX-APPLICATION-EXTENSION"
         ],
         "thumbnails": [
             {

--- a/samples/react-command-custom-command-bar/assets/sample.json
+++ b/samples/react-command-custom-command-bar/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-demote-news/assets/sample.json
+++ b/samples/react-command-demote-news/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-dialog/assets/sample.json
+++ b/samples/react-command-dialog/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-direct-link/assets/sample.json
+++ b/samples/react-command-direct-link/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-directions/assets/sample.json
+++ b/samples/react-command-directions/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-discuss-now/assets/sample.json
+++ b/samples/react-command-discuss-now/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-file-size-viewer/assets/sample.json
+++ b/samples/react-command-file-size-viewer/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-folder-select/assets/sample.json
+++ b/samples/react-command-folder-select/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-follow-document/Assets/sample.json
+++ b/samples/react-command-follow-document/Assets/sample.json
@@ -27,7 +27,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-form-settings/assets/sample.json
+++ b/samples/react-command-form-settings/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-get-thumbnail/assets/sample.json
+++ b/samples/react-command-get-thumbnail/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-image-editor/assets/sample.json
+++ b/samples/react-command-image-editor/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-mail-view-as-image/assets/sample.json
+++ b/samples/react-command-mail-view-as-image/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-page-model-pnpjs/assets/sample.json
+++ b/samples/react-command-page-model-pnpjs/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-print/assets/sample.json
+++ b/samples/react-command-print/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-qrcode/assets/sample.json
+++ b/samples/react-command-qrcode/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-share-pnpjs/assets/sample.json
+++ b/samples/react-command-share-pnpjs/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-singlepartapppage/assets/sample.json
+++ b/samples/react-command-singlepartapppage/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-command-vision-api/README.md
+++ b/samples/react-command-vision-api/README.md
@@ -51,7 +51,7 @@ Version|Date|Comments
 
 ## Prerequisites
 
-* Office 365 Developer tenant First Release (this sample uses [sfpx Tenant Properties](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties))
+* Office 365 Developer tenant First Release (this sample uses [spfx Tenant Properties](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties))
 * Library with Images
 * Cognitive Services Vision API Key (more info [https://azure.microsoft.com/en-us/services/cognitive-services/](https://azure.microsoft.com/en-us/services/cognitive-services/))
 

--- a/samples/react-command-vision-api/assets/sample.json
+++ b/samples/react-command-vision-api/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-field-attachment-info/assets/sample.json
+++ b/samples/react-field-attachment-info/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-field-pnp-field-renderer-helper/assets/sample.json
+++ b/samples/react-field-pnp-field-renderer-helper/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-field-pnp-file-type-renderer/assets/sample.json
+++ b/samples/react-field-pnp-file-type-renderer/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-field-slider/assets/sample.json
+++ b/samples/react-field-slider/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-field-text-analytics-api/assets/sample.json
+++ b/samples/react-field-text-analytics-api/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-field-toggle/assets/sample.json
+++ b/samples/react-field-toggle/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-field-user-permission/assets/sample.json
+++ b/samples/react-field-user-permission/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-FIELD-EXTENSION"
+      "SPFX-FIELD-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-hidefrom-externalusers/assets/sample.json
+++ b/samples/react-hidefrom-externalusers/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-item-History/assets/sample.json
+++ b/samples/react-item-History/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-jump-to-folder/assets/sample.json
+++ b/samples/react-jump-to-folder/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-mega-menu/assets/sample.json
+++ b/samples/react-mega-menu/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-menu-footer-classic-modern/assets/sample.json
+++ b/samples/react-menu-footer-classic-modern/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-msal-bot/assets/sample.json
+++ b/samples/react-msal-bot/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-APPLICATION-EXTENSION"
+      "SPFX-APPLICATION-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-send-document/assets/sample.json
+++ b/samples/react-send-document/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {

--- a/samples/react-send-to-teams/assets/sample.json
+++ b/samples/react-send-to-teams/assets/sample.json
@@ -26,7 +26,7 @@
     ],
 "tags": [],
     "categories": [
-      "SFPX-COMMAND-EXTENSION"
+      "SPFX-COMMAND-EXTENSION"
     ],
     "thumbnails": [
       {


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bugfix?        | yes|
| New feature?    | no                               |
| New sample?     | no                               |

## What's in this Pull Request?

Updated the sample browser 'sample.json' files category reference to SPFx. The incorrect acronym of "SFPX" was being used. I corrected it to "SPFX".

I hope I submitted this correctly. I attended a "Sharing is Caring" session with the two bald dudes. At least I think there were two of them. Honestly, it may have been one dude with two cameras....in fact I think that is the case. 
