### PR TITLE
Fix two broken references in "react-company-templates"

### DIFF
--- a/samples/react-company-templates/.yo-rc.json
+++ b/samples/react-company-templates/.yo-rc.json
@@ -9,7 +9,7 @@
     },
     "version": "1.17.4",
     "libraryName": "company-templates",
-    "libraryId": "fb423a64-9c98-42de-b873-e2fe1231e30a",
+    "libraryId": "3c272c73-7281-4642-8dd9-2cd670f130f2",
     "environment": "spo",
     "packageManager": "npm",
     "solutionName": "Company-templates",

--- a/samples/react-company-templates/config/package-solution.json
+++ b/samples/react-company-templates/config/package-solution.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/package-solution.schema.json",
   "solution": {
     "name": "spo-templates-extension-client-side-solution",
-    "id": "fb423a64-9c98-42de-b873-e2fe1231e30a",
+    "id": "3c272c73-7281-4642-8dd9-2cd670f130f2",
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,

--- a/samples/react-company-templates/sharepoint/assets/ClientSideInstance.xml
+++ b/samples/react-company-templates/sharepoint/assets/ClientSideInstance.xml
@@ -2,14 +2,8 @@
 <Elements xmlns="http://schemas.microsoft.com/sharepoint/">
     <ClientSideComponentInstance
         Title="CompanyTemplates"
-        Location="ClientSideExtension.ListViewCommandSet.ContextMenu"
-        ListTemplateId="100"
-        Properties="{}"
-        ComponentId="4dc2355b-e74a-4cac-9e4a-cf1cc28ef90c" />
-            <ClientSideComponentInstance
-        Title="CompanyTemplates"
-        Location="ClientSideExtension.ListViewCommandSet.ContextMenu"
+        Location="ClientSideExtension.ListViewCommandSet.CommandBar"
         ListTemplateId="101"
         Properties="{}"
-        ComponentId="4dc2355b-e74a-4cac-9e4a-cf1cc28ef90c" />
+        ComponentId="532b1c1d-bcbd-4831-a821-ec95eac1ca1c" />
 </Elements>

--- a/samples/react-company-templates/sharepoint/assets/elements.xml
+++ b/samples/react-company-templates/sharepoint/assets/elements.xml
@@ -4,7 +4,7 @@
         Title="CompanyTemplates"
         RegistrationId="101"
         RegistrationType="List"
-        Location="ClientSideExtension.ListViewCommandSet.ContextMenu"
+        Location="ClientSideExtension.ListViewCommandSet.CommandBar"
         ClientSideComponentId="532b1c1d-bcbd-4831-a821-ec95eac1ca1c"
         ClientSideComponentProperties="{}">
     </CustomAction>


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |

## What's in this Pull Request?

This PR fixes three incorrect references due to copy-paste errors in the solution template used by the author. 
That said, it changes
- the solution id to ensure sure it won't clash with any solution id that is used in another sample extension
- the location of the action button of the command set and
- the component reference of the action button to match the correct extension id used in the manifest

This update is necessary, otherwise the solution can cause side effects when using it in production.