### PR TITLE
Fix broken references and user permission check in "react-company-templates"

### DIFF
--- a/samples/react-company-templates/.yo-rc.json
+++ b/samples/react-company-templates/.yo-rc.json
@@ -9,7 +9,7 @@
     },
     "version": "1.17.4",
     "libraryName": "company-templates",
-    "libraryId": "fb423a64-9c98-42de-b873-e2fe1231e30a",
+    "libraryId": "3c272c73-7281-4642-8dd9-2cd670f130f2",
     "environment": "spo",
     "packageManager": "npm",
     "solutionName": "Company-templates",

--- a/samples/react-company-templates/README.md
+++ b/samples/react-company-templates/README.md
@@ -28,7 +28,7 @@ From a user perspective, the extension covers these features:
 - [x] Filter by file category
 - [x] Filter by name
 - [x] Copy selected files from template repository to the current document library
-- [x] Show a settings page to all users who have permissions to manage lists
+- [x] Show a settings page to all users who are (at least) site admins
 
 It uses several ["Reusable React controls"](https://pnp.github.io/sp-dev-fx-controls-react/) for an awesome user experience.
 

--- a/samples/react-company-templates/assets/sample.json
+++ b/samples/react-company-templates/assets/sample.json
@@ -10,7 +10,7 @@
             "This is an alternative to the built-in 'New document' experience in a document library in SharePoint Online. It allows a SharePoint admin to define a repository (such as a standard document library or an org assets library) which acts as a source of templates that can be used in every document library. Any user can browse through the collection of company templates, get an instance of the desired template(s) by one single click and start using it."
         ],
         "creationDateTime": "2023-12-22",
-        "updateDateTime": "2024-03-29",
+        "updateDateTime": "2024-04-06",
         "products": [
             "SharePoint"
         ],

--- a/samples/react-company-templates/assets/sample.json
+++ b/samples/react-company-templates/assets/sample.json
@@ -4,8 +4,8 @@
         "source": "pnp",
         "title": "Company Templates",
         "shortDescription": "An extension to provide a simple approach for company wide used templates in SharePoint Online.",
-        "url": "https://github.com/pnp/sp-dev-fx-webparts/tree/main/samples/react-company-templates",
-        "downloadUrl": "https://pnp.github.io/download-partial/?url=https://github.com/pnp/sp-dev-fx-webparts/tree/main/samples/react-company-templates",
+        "url": "https://github.com/pnp/sp-dev-fx-extensions/tree/main/samples/react-company-templates",
+        "downloadUrl": "https://pnp.github.io/download-partial/?url=https://github.com/pnp/sp-dev-fx-extensions/tree/main/samples/react-company-templates",
         "longDescription": [
             "This is an alternative to the built-in 'New document' experience in a document library in SharePoint Online. It allows a SharePoint admin to define a repository (such as a standard document library or an org assets library) which acts as a source of templates that can be used in every document library. Any user can browse through the collection of company templates, get an instance of the desired template(s) by one single click and start using it."
         ],

--- a/samples/react-company-templates/config/package-solution.json
+++ b/samples/react-company-templates/config/package-solution.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/package-solution.schema.json",
   "solution": {
     "name": "spo-templates-extension-client-side-solution",
-    "id": "fb423a64-9c98-42de-b873-e2fe1231e30a",
+    "id": "3c272c73-7281-4642-8dd9-2cd670f130f2",
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,

--- a/samples/react-company-templates/sharepoint/assets/ClientSideInstance.xml
+++ b/samples/react-company-templates/sharepoint/assets/ClientSideInstance.xml
@@ -2,14 +2,8 @@
 <Elements xmlns="http://schemas.microsoft.com/sharepoint/">
     <ClientSideComponentInstance
         Title="CompanyTemplates"
-        Location="ClientSideExtension.ListViewCommandSet.ContextMenu"
-        ListTemplateId="100"
-        Properties="{}"
-        ComponentId="4dc2355b-e74a-4cac-9e4a-cf1cc28ef90c" />
-            <ClientSideComponentInstance
-        Title="CompanyTemplates"
-        Location="ClientSideExtension.ListViewCommandSet.ContextMenu"
+        Location="ClientSideExtension.ListViewCommandSet.CommandBar"
         ListTemplateId="101"
         Properties="{}"
-        ComponentId="4dc2355b-e74a-4cac-9e4a-cf1cc28ef90c" />
+        ComponentId="532b1c1d-bcbd-4831-a821-ec95eac1ca1c" />
 </Elements>

--- a/samples/react-company-templates/sharepoint/assets/elements.xml
+++ b/samples/react-company-templates/sharepoint/assets/elements.xml
@@ -4,7 +4,7 @@
         Title="CompanyTemplates"
         RegistrationId="101"
         RegistrationType="List"
-        Location="ClientSideExtension.ListViewCommandSet.ContextMenu"
+        Location="ClientSideExtension.ListViewCommandSet.CommandBar"
         ClientSideComponentId="532b1c1d-bcbd-4831-a821-ec95eac1ca1c"
         ClientSideComponentProperties="{}">
     </CustomAction>

--- a/samples/react-company-templates/src/extensions/companyTemplates/CompanyTemplatesCommandSet.ts
+++ b/samples/react-company-templates/src/extensions/companyTemplates/CompanyTemplatesCommandSet.ts
@@ -38,17 +38,17 @@ export default class CompanyTemplatesCommandSet extends BaseListViewCommandSet<I
   }
 
   private handleCommands(): void {
-    const compareOneCommand: Command = this.tryGetCommand('COMPANY_TEMPLATES');
+    const templatesCmd: Command = this.tryGetCommand('COMPANY_TEMPLATES');
 
     const fillColor = getThemeColor("themeDarkAlt").replace('#', '%23');
     const exportSvg = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2048 2048'%3E%3Cpath d='M608 128q45 0 77 9t58 24 46 31 40 31 44 23 55 10h992q27 0 50 10t40 27 28 41 10 50v451l-128-128V384H928q-31 0-54 9t-44 24-41 31-45 31-58 23-78 10H128v1152h640v128H0V256q0-27 10-50t27-40 41-28 50-10h480zm0 256q24 0 42-4t33-13 29-20 32-27q-17-15-31-26t-30-20-33-13-42-5H128v128h480zm1019 256l421 421v987H896V640h731zm37 384h165l-165-165v165zm256 128h-384V768h-512v1152h896v-768zm-768 512h512v128h-512v-128zm256-128h-256v-128h256v128zm0-256h-256v-128h256v128zm0-256h-256V896h256v128z' fill='${fillColor}'%3E%3C/path%3E%3C/svg%3E`;
-    compareOneCommand.iconImageUrl = exportSvg;
+    templatesCmd.iconImageUrl = exportSvg;
 
     // initial state of the command's visibility
-    compareOneCommand.visible = false;
+    templatesCmd.visible = false;
     const userListPermission = new SPPermission(this.context.pageContext.list.permissions.value);
     if (userListPermission.hasPermission(SPPermission.addListItems)) {
-      compareOneCommand.visible = true;
+      templatesCmd.visible = true;
     }
 
     this.context.listView.listViewStateChangedEvent.add(this, this._onListViewStateChanged);

--- a/samples/react-company-templates/src/extensions/companyTemplates/CompanyTemplatesCommandSet.ts
+++ b/samples/react-company-templates/src/extensions/companyTemplates/CompanyTemplatesCommandSet.ts
@@ -39,14 +39,15 @@ export default class CompanyTemplatesCommandSet extends BaseListViewCommandSet<I
 
   private handleCommands(): void {
     const compareOneCommand: Command = this.tryGetCommand('COMPANY_TEMPLATES');
-    
+
     const fillColor = getThemeColor("themeDarkAlt").replace('#', '%23');
     const exportSvg = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2048 2048'%3E%3Cpath d='M608 128q45 0 77 9t58 24 46 31 40 31 44 23 55 10h992q27 0 50 10t40 27 28 41 10 50v451l-128-128V384H928q-31 0-54 9t-44 24-41 31-45 31-58 23-78 10H128v1152h640v128H0V256q0-27 10-50t27-40 41-28 50-10h480zm0 256q24 0 42-4t33-13 29-20 32-27q-17-15-31-26t-30-20-33-13-42-5H128v128h480zm1019 256l421 421v987H896V640h731zm37 384h165l-165-165v165zm256 128h-384V768h-512v1152h896v-768zm-768 512h512v128h-512v-128zm256-128h-256v-128h256v128zm0-256h-256v-128h256v128zm0-256h-256V896h256v128z' fill='${fillColor}'%3E%3C/path%3E%3C/svg%3E`;
     compareOneCommand.iconImageUrl = exportSvg;
-    
+
     // initial state of the command's visibility
     compareOneCommand.visible = false;
-    if (this.context.pageContext.web.permissions.hasPermission(SPPermission.addListItems)) {
+    const userListPermission = new SPPermission(this.context.pageContext.list.permissions.value);
+    if (userListPermission.hasPermission(SPPermission.addListItems)) {
       compareOneCommand.visible = true;
     }
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |

## What's in this Pull Request?

This PR fixes three incorrect references due to copy-paste errors in the solution template used by the author. Moreover, it addresses an erroneous user permission check to set the correct visibility of the command and "prettifies" some declarations.
That said, it changes
1. the solution id to ensure sure it won't clash with any solution id that is used in another sample extension
2. the location of the action button of the command set
3. the component reference of the action button to match the correct extension id used in the manifest
4. the permission check for the user's permissions on the actual document library
**There was no security issue in this extension before** – the current permission fix implements better user experience: it now hides the command button for any user that has no permission to add documents to the library.

Nevertheless, this update is necessary, otherwise the solution can cause side effects due to incorrect references when using it in production.