### PR TITLE
Fill missing properties in React Document Reporting Field Customizer sample.json

### DIFF
--- a/samples/react-field-reporting/assets/sample.json
+++ b/samples/react-field-reporting/assets/sample.json
@@ -2,11 +2,11 @@
     {
         "name": "pnp-sp-dev-spfx-extensions-react-field-reporting",
         "source": "pnp",
-        "title": "TODO: TITLE-GOES-HERE",
-        "shortDescription": "DESCRIPTION-GOES-HERE",
+        "title": "React Document Reporting Field Customizer",
+        "shortDescription": "A React-based SPFx application for monitoring user activity within SharePoint documents.",
         "url": "https://github.com/pnp/sp-dev-fx-extensions/tree/main/samples/react-field-reporting",
         "longDescription": [
-            "TODO: LONG-DESCRIPTION-GOES-HERE"
+            "This application logs details about who has opened a document into Application Insights and displays real-time reporting data in tabular and chart formats."
         ],
         "creationDateTime": "2023-12-25",
         "updateDateTime": "2023-12-31",


### PR DESCRIPTION
Fixes #1396

Update `sample.json` to replace `TODO` placeholders with relevant content.

* **Title**: Replace "TODO: TITLE-GOES-HERE" with "React Document Reporting Field Customizer".
* **Short Description**: Replace "DESCRIPTION-GOES-HERE" with "A React-based SPFx application for monitoring user activity within SharePoint documents."
* **Long Description**: Replace "TODO: LONG-DESCRIPTION-GOES-HERE" with "This application logs details about who has opened a document into Application Insights and displays real-time reporting data in tabular and chart formats."

.... Change fully generated by GitHub workspace and Copilot.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pnp/sp-dev-fx-extensions/issues/1396?shareId=ced0708c-2d13-45f1-86df-ab02ba232f7c).