### PR TITLE
Add PR validation workflow

### DIFF
--- a/.github/workflows/validate-sample-pr.yml
+++ b/.github/workflows/validate-sample-pr.yml
@@ -1,0 +1,51 @@
+name: Validate SPFx Extensions Sample PR
+
+on:
+  pull_request_target:
+    branches:
+      - "main"
+
+jobs:
+  validate:
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'skip-validation')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Run Validate SPFx Sample PR Action
+        id: validate-spfx-sample-pr
+        uses: pnp/action-pr-validator@v1.1.1
+        with:
+          pr: ${{ toJson(github.event.pull_request) }}
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          postComment: 'true'
+
+      - name: add success label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: steps.validate-spfx-sample-pr.outputs.valid == 'true'
+        with:
+          labels: "Sample validation: Success"
+
+      - name: remove warning label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: steps.validate-spfx-sample-pr.outputs.valid == 'true'
+        with:
+          labels: "Sample validation: Warning"
+        continue-on-error: true
+
+      - name: add warning label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: steps.validate-spfx-sample-pr.outputs.valid == 'false'
+        with:
+          labels: "Sample validation: Warning"
+
+      - name: remove success label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: steps.validate-spfx-sample-pr.outputs.valid == 'false'
+        with:
+          labels: "Sample validation: Success"
+        continue-on-error: true

--- a/.github/workflows/validate-sample.yml
+++ b/.github/workflows/validate-sample.yml
@@ -1,4 +1,4 @@
-name: Sample validation
+name: PnP Sample.json validation
 
 on:
   pull_request_target:
@@ -7,6 +7,7 @@ on:
 
 jobs:
   validate:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Validate


### PR DESCRIPTION
## Summary

- Add the same PR-level sample validation workflow used by pnp/sp-dev-fx-webparts, adapted for SPFx Extensions naming.
- Align the existing sample.json validation workflow name and dependabot guard with the webparts repo.

## Details

The webparts repo has two PR validation workflows:

- .github/workflows/validate-sample.yml runs pnp/pnp-sample-validation@main for PRs targeting main, excluding Dependabot.
- .github/workflows/validate-sample-pr.yml runs pnp/action-pr-validator@v1.1.1, posts validation comments, and manages the Sample validation: Success / Sample validation: Warning labels, excluding Dependabot and PRs labeled skip-validation.

Extensions already had the first workflow but was missing the dependabot guard, and did not have the second workflow.

## Validation

- Compared workflow files in pnp/sp-dev-fx-webparts and pnp/sp-dev-fx-extensions.
- Ran git diff --check on the workflow changes.
